### PR TITLE
Add back support for legacy (RFC8291 draft 4) encryption

### DIFF
--- a/lib/webpush.rb
+++ b/lib/webpush.rb
@@ -10,6 +10,7 @@ require 'webpush/version'
 require 'webpush/errors'
 require 'webpush/vapid_key'
 require 'webpush/encryption'
+require 'webpush/legacy/encryption'
 require 'webpush/request'
 require 'webpush/railtie' if defined?(Rails)
 

--- a/lib/webpush/legacy/encryption.rb
+++ b/lib/webpush/legacy/encryption.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Webpush
+  module Legacy
+    module Encryption
+      # This implements RFC8291 draft 4:
+      # https://datatracker.ietf.org/doc/html/draft-ietf-webpush-encryption-04
+
+      extend self
+
+      def encrypt(message, p256dh, auth)
+        assert_arguments(message, p256dh, auth)
+  
+        group_name = 'prime256v1'
+        salt = Random.new.bytes(16)
+  
+        server = OpenSSL::PKey::EC.generate(group_name)
+        server_public_key_bn = server.public_key.to_bn
+  
+        group = OpenSSL::PKey::EC::Group.new(group_name)
+        client_public_key_bn = OpenSSL::BN.new(Webpush.decode64(p256dh), 2)
+        client_public_key = OpenSSL::PKey::EC::Point.new(group, client_public_key_bn)
+  
+        shared_secret = server.dh_compute_key(client_public_key)
+  
+        client_auth_token = Webpush.decode64(auth)
+  
+        prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: "Content-Encoding: auth\0").next_bytes(32)
+  
+        context = create_context(client_public_key_bn, server_public_key_bn)
+  
+        content_encryption_key_info = create_info('aesgcm', context)
+        content_encryption_key = HKDF.new(prk, salt: salt, info: content_encryption_key_info).next_bytes(16)
+  
+        nonce_info = create_info('nonce', context)
+        nonce = HKDF.new(prk, salt: salt, info: nonce_info).next_bytes(12)
+  
+        ciphertext = encrypt_payload(message, content_encryption_key, nonce)
+  
+        {
+          ciphertext: ciphertext,
+          salt: salt,
+          server_public_key_bn: server_public_key_bn.to_s(2),
+          server_public_key: server_public_key_bn.to_s(2),
+          shared_secret: shared_secret
+        }
+      end
+
+      private
+  
+      def assert_arguments(message, p256dh, auth)
+        raise ArgumentError, 'message cannot be blank' if blank?(message)
+        raise ArgumentError, 'p256dh cannot be blank' if blank?(p256dh)
+        raise ArgumentError, 'auth cannot be blank' if blank?(auth)
+      end
+  
+      def blank?(value)
+        value.nil? || value.empty?
+      end
+
+      def create_context(client_public_key, server_public_key)
+        c = client_public_key.to_s(2)
+        s = server_public_key.to_s(2)
+        "\0#{[c.bytesize].pack('n*')}#{c}#{[s.bytesize].pack('n*')}#{s}"
+      end
+
+      def encrypt_payload(plaintext, content_encryption_key, nonce)
+        cipher = OpenSSL::Cipher.new('aes-128-gcm')
+        cipher.encrypt
+        cipher.key = content_encryption_key
+        cipher.iv = nonce
+        padding = cipher.update("\0\0")
+        text = cipher.update(plaintext)
+
+        e_text = padding + text + cipher.final
+        e_tag = cipher.auth_tag
+  
+        e_text + e_tag
+      end
+
+      def create_info(type, context)
+        "Content-Encoding: #{type}\0P-256#{context}"
+      end
+    end
+  end
+end

--- a/spec/webpush/legacy/encryption_spec.rb
+++ b/spec/webpush/legacy/encryption_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+describe Webpush::Legacy::Encryption do
+  describe '#encrypt' do
+    let(:curve) do
+      group = 'prime256v1'
+      OpenSSL::PKey::EC.generate(group)
+    end
+
+    let(:p256dh) do
+      ecdh_key = curve.public_key.to_bn.to_s(2)
+      Base64.urlsafe_encode64(ecdh_key)
+    end
+
+    let(:auth) { Base64.urlsafe_encode64(Random.new.bytes(16)) }
+
+    it 'returns ECDH encrypted cipher text, salt, and server_public_key' do
+      payload = Webpush::Legacy::Encryption.encrypt('Hello World', p256dh, auth)
+      expect(decrypt(payload)).to eq('Hello World')
+    end
+
+    it 'returns error when message is blank' do
+      expect { Webpush::Legacy::Encryption.encrypt(nil, p256dh, auth) }.to raise_error(ArgumentError)
+      expect { Webpush::Legacy::Encryption.encrypt('', p256dh, auth) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns error when p256dh is blank' do
+      expect { Webpush::Legacy::Encryption.encrypt('Hello world', nil, auth) }.to raise_error(ArgumentError)
+      expect { Webpush::Legacy::Encryption.encrypt('Hello world', '', auth) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns error when auth is blank' do
+      expect { Webpush::Legacy::Encryption.encrypt('Hello world', p256dh, '') }.to raise_error(ArgumentError)
+      expect { Webpush::Legacy::Encryption.encrypt('Hello world', p256dh, nil) }.to raise_error(ArgumentError)
+    end
+
+    # Bug fix for https://github.com/zaru/webpush/issues/22
+    it 'handles unpadded base64 encoded subscription keys' do
+      unpadded_p256dh = p256dh.gsub(/=*\Z/, '')
+      unpadded_auth = auth.gsub(/=*\Z/, '')
+
+      payload = Webpush::Legacy::Encryption.encrypt('Hello World', unpadded_p256dh, unpadded_auth)
+      expect(decrypt(payload)).to eq('Hello World')
+    end
+
+    def decrypt(payload)
+      salt = payload.fetch(:salt)
+      serverkey16bn = payload.fetch(:server_public_key_bn)
+      ciphertext = payload.fetch(:ciphertext)
+
+      group_name = 'prime256v1'
+      group = OpenSSL::PKey::EC::Group.new(group_name)
+      server_public_key_bn = OpenSSL::BN.new(serverkey16bn.unpack('H*').first, 16)
+      server_public_key = OpenSSL::PKey::EC::Point.new(group, server_public_key_bn)
+      shared_secret = curve.dh_compute_key(server_public_key)
+
+      client_public_key_bn = curve.public_key.to_bn
+      client_auth_token = Webpush.decode64(auth)
+
+      info = "Content-Encoding: auth\0"
+      context = create_context(curve.public_key, server_public_key)
+      content_encryption_key_info = "Content-Encoding: aesgcm\0P-256#{context}"
+      nonce_info = "Content-Encoding: nonce\0P-256#{context}"
+
+      prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: info).next_bytes(32)
+
+      content_encryption_key = HKDF.new(prk, salt: salt, info: content_encryption_key_info).next_bytes(16)
+      nonce = HKDF.new(prk, salt: salt, info: nonce_info).next_bytes(12)
+
+      decrypt_ciphertext(ciphertext, content_encryption_key, nonce)
+    end
+
+    def create_context(client_public_key, server_public_key)
+      c = client_public_key.to_bn.to_s(2)
+      s = server_public_key.to_bn.to_s(2)
+      context = "\0"
+      context += [c.bytesize].pack("n*")
+      context += c
+      context += [s.bytesize].pack("n*")
+      context += s
+      context
+    end
+
+    def decrypt_ciphertext(ciphertext, content_encryption_key, nonce)
+      secret_data = ciphertext.byteslice(0, ciphertext.bytesize-16)
+      auth = ciphertext.byteslice(ciphertext.bytesize-16, ciphertext.bytesize)
+      decipher = OpenSSL::Cipher.new('aes-128-gcm')
+      decipher.decrypt
+      decipher.key = content_encryption_key
+      decipher.iv = nonce
+      decipher.auth_tag = auth
+
+      decrypted = decipher.update(secret_data) + decipher.final
+
+      e = decrypted.byteslice(0, 2)
+      expect(e).to eq("\0\0")
+
+      decrypted.byteslice(2, decrypted.bytesize-2)
+    end
+  end
+end


### PR DESCRIPTION
This adds back support for what `Webpush::Encryption` was in v0.3.8, so that we can support both in Mastodon.